### PR TITLE
Replaced cache.find with fetch()

### DIFF
--- a/src/events/Content Events/interactionCreate.ts
+++ b/src/events/Content Events/interactionCreate.ts
@@ -5,7 +5,7 @@ import { BaseCommand } from "../../structures/SlashCommand";
 export const event: Event = {
    name: "interactionCreate"
 }
-export const run: Run = (client, interaction: Interaction) => {
+export const run: Run = async (client, interaction: Interaction) => {
      
    if (interaction.isCommand()) {
       const command = client.slashCommands.find(cmd => cmd.name === interaction.commandName) as BaseCommand
@@ -21,7 +21,7 @@ export const run: Run = (client, interaction: Interaction) => {
              args.push(option.value);
           }
       }
-      interaction.member = interaction.guild.members.cache.find(m => m.id === interaction.user.id)
+      interaction.member = await interaction.guild.members.fetch(interaction.user.id)
       command.run(client, interaction, args)
    }
 


### PR DESCRIPTION
Members are not always cached so cache is unreliable in this case, so it's recommended to fetch instead (which searches for the cache first just in case).